### PR TITLE
Handle failed searches and show progress indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
                     <div id="topic-title" class="topic-title"></div>
                     <div id="fetching-indicator">
                         <div class="loader small"></div>
+                        <span id="fetching-text"></span>
                     </div>
                 </div>
                 <nav class="tabs">

--- a/script.js
+++ b/script.js
@@ -348,10 +348,7 @@ async function handleSearch(topic, isInitial = false) {
         cards = await generateCardsFromAI(10, topic);
     } catch (err) {
         console.error(err);
-        cards = [
-            { id: `${topic}-fallback-0`, title: `フォールバック: ${topic} 1`, point: '生成に失敗したため暫定', detail: '', code: '' },
-            { id: `${topic}-fallback-1`, title: `フォールバック: ${topic} 2`, point: '生成に失敗したため暫定', detail: '', code: '' }
-        ];
+        cards = createFallbackCards(topic);
     }
     dom.fetchingText.textContent = 'カード表示中...';
     try {

--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,20 @@ body {
     height: 48px
 }
 
+#fetching-indicator {
+    display: none;
+    align-items: center;
+    gap: 6px;
+}
+
+#fetching-indicator.visible {
+    display: flex;
+}
+
+#fetching-indicator span {
+    font-size: .8rem;
+}
+
 .topic-title {
     font-weight: 700;
     white-space: nowrap;


### PR DESCRIPTION
## Summary
- Fix stuck search by adding fallback cards when AI generation fails
- Add textual progress indicator and hide spinner when not fetching
- Style fetching indicator visibility with CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab96a2e38c832f94db529f0b8ea919