### PR TITLE
Fix fetching indicator layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -92,7 +92,10 @@ body {
     font-weight: 700;
     white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+    text-align: center
 }
 
 .tabs {


### PR DESCRIPTION
## Summary
- Ensure the "fetching" indicator remains visible by giving the topic title flex sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9aac75cc832fa2b86ed2afed00f4