### PR TITLE
feat: show AI failure message

### DIFF
--- a/script.js
+++ b/script.js
@@ -168,7 +168,7 @@ async function generateCardsFromAI(count, topic = '全般') {
         resultText = await callLLM(prompt, schema);
     } catch (err) {
         console.error(err);
-        return createFallbackCards(topic);
+        throw err;
     }
     setDebugRaw('RAW:\n' + String(resultText).slice(0, 5000));
 
@@ -176,7 +176,8 @@ async function generateCardsFromAI(count, topic = '全般') {
     try {
         arr = safeParseJsonArray(resultText);
     } catch (parseErr) {
-        return createFallbackCards(topic);
+        console.error(parseErr);
+        throw parseErr;
     }
 
     const now = Date.now();
@@ -358,6 +359,8 @@ async function handleSearch(topic, isInitial = false) {
         cards = await generateCardsFromAI(10, topic);
     } catch (err) {
         console.error(err);
+        dom.fetchingText.textContent = 'AI生成に失敗しました。代替カードを表示します';
+        setTimeout(() => { if (dom.fetchingText) dom.fetchingText.textContent = ''; }, 2000);
         cards = createFallbackCards(topic);
     }
     dom.fetchingText.textContent = 'カード表示中...';


### PR DESCRIPTION
## Summary
- show a user-facing message when AI generation fails
- throw errors from card generation instead of silently falling back

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abd884f138832fb0a62abad01a24ba